### PR TITLE
Ignore _BBN if isn't a PCI root bus

### DIFF
--- a/core/ns.c
+++ b/core/ns.c
@@ -759,3 +759,11 @@ uint8_t lai_ns_get_opregion_address_space(lai_nsnode_t *node){
     LAI_ENSURE(node->type == LAI_NAMESPACE_OPREGION);
     return node->op_address_space;
 }
+
+int lai_is_pci_root_bus(lai_nsnode_t *dev,lai_state_t *state){
+    LAI_CLEANUP_VAR lai_variable_t pci_pnp_id = LAI_VAR_INITIALIZER;
+    LAI_CLEANUP_VAR lai_variable_t pcie_pnp_id = LAI_VAR_INITIALIZER;
+    lai_eisaid(&pci_pnp_id, ACPI_PCI_PNP_ID);
+    lai_eisaid(&pcie_pnp_id, ACPI_PCIE_PNP_ID);
+    return lai_check_device_pnp_id(dev, &pci_pnp_id, state) || lai_check_device_pnp_id(dev, &pcie_pnp_id, state);
+}

--- a/core/opregion.c
+++ b/core/opregion.c
@@ -91,6 +91,7 @@ static void eval_bbn(lai_nsnode_t *opregion, uint64_t *bbn, lai_state_t * state)
                     return;
                 }
             }
+            return;
         }else{
             opregion=opregion->parent;
         }

--- a/core/opregion.c
+++ b/core/opregion.c
@@ -93,15 +93,18 @@ static void lai_get_pci_params(lai_nsnode_t *opregion, uint64_t *seg, uint64_t *
         if (seg)
             *seg = seg_number.integer;
     }
-
-    // PCI bus number is in the _BBN object.
-    lai_nsnode_t *bbn_handle = lai_resolve_search(opregion, "_BBN");
-    if (bbn_handle) {
-        if (lai_eval(&bus_number, bbn_handle, &state))
-            lai_panic("could not evaluate _BBN of OperationRegion()");
-        if (bbn)
-            *bbn = bus_number.integer;
+    
+    if(opregion->name[0]=='P'&&opregion->name[1]=='C'&&opregion->name[2]=='I'&&opregion->name[3]>='0'&&opregion->name[3]<='9'){//only evaluate _BBN if is PCI root node
+        // PCI bus number is in the _BBN object.
+        lai_nsnode_t *bbn_handle = lai_resolve_search(opregion, "_BBN");
+        if (bbn_handle) {
+            if (lai_eval(&bus_number, bbn_handle, &state))
+                lai_panic("could not evaluate _BBN of OperationRegion()");
+            if (bbn)
+                *bbn = bus_number.integer;
+        }
     }
+    
 
     // Device slot/function is in the _ADR object.
     lai_nsnode_t *adr_handle = lai_resolve_search(opregion, "_ADR");

--- a/core/opregion.c
+++ b/core/opregion.c
@@ -84,7 +84,7 @@ static void eval_bbn(lai_nsnode_t *opregion, uint64_t *bbn, lai_state_t * state)
             // PCI bus number is in the _BBN object.
             lai_nsnode_t *bbn_handle = lai_resolve_search(opregion, "_BBN");
             if (bbn_handle) {
-                if (lai_eval(&bus_number, bbn_handle, &state))
+                if (lai_eval(&bus_number, bbn_handle, state))
                     lai_panic("could not evaluate _BBN of OperationRegion()");
                 if (bbn){
                     *bbn = bus_number.integer;

--- a/helpers/pci.c
+++ b/helpers/pci.c
@@ -14,7 +14,7 @@
 
 #include <lai/helpers/pci.h>
 #include <lai/helpers/resource.h>
-#include <lai/acpispec/hw.h>
+#include <acpispec/hw.h>
 #include "../core/libc.h"
 #include "../core/eval.h"
 

--- a/helpers/pci.c
+++ b/helpers/pci.c
@@ -221,14 +221,18 @@ lai_nsnode_t *lai_pci_find_bus(uint16_t seg, uint8_t bus, lai_state_t *state){
 
         LAI_CLEANUP_VAR lai_variable_t bus_number = LAI_VAR_INITIALIZER;
         uint64_t bbn_result = 0;
-        lai_nsnode_t *bbn_handle = lai_resolve_path(node, "_BBN");
-        if (bbn_handle) {
-            if (lai_eval(&bus_number, bbn_handle, state)) {
-                lai_warn("failed to evaluate _BBN");
-                continue;
+        
+        if(node->name[0]=='P'&&node->name[1]=='C'&&node->name[2]=='I'&&node->name[3]>='0'&&node->name[3]<='9'){//only evaluate _BBN if is PCI root node
+            lai_nsnode_t *bbn_handle = lai_resolve_path(node, "_BBN");
+            if (bbn_handle) {
+                if (lai_eval(&bus_number, bbn_handle, state)) {
+                    lai_warn("failed to evaluate _BBN");
+                    continue;
+                }
+                lai_obj_get_integer(&bus_number, &bbn_result);
             }
-            lai_obj_get_integer(&bus_number, &bbn_result);
         }
+        
 
         LAI_CLEANUP_VAR lai_variable_t seg_number = LAI_VAR_INITIALIZER;
         uint64_t seg_result = 0;

--- a/include/acpispec/hw.h
+++ b/include/acpispec/hw.h
@@ -30,6 +30,9 @@ extern "C" {
 #define ACPI_EC_STATUS_SCI_EVT 0x20 // SCI event pending
 #define ACPI_EC_STATUS_SMI_EVT 0x40 // SMI event pending
 
+#define ACPI_PCI_PNP_ID        "PNP0A03"
+#define ACPI_PCIE_PNP_ID       "PNP0A08"
+
 #ifdef __cplusplus
 }
 #endif

--- a/include/lai/core.h
+++ b/include/lai/core.h
@@ -74,6 +74,7 @@ lai_nsnode_t *lai_enum(char *, size_t);
 void lai_eisaid(lai_variable_t *, const char *);
 lai_nsnode_t *lai_ns_iterate(struct lai_ns_iterator *);
 lai_nsnode_t *lai_ns_child_iterate(struct lai_ns_child_iterator *);
+int lai_is_pci_root_bus(lai_nsnode_t *,lai_state_t *);
 
 // Namespace functions.
 


### PR DESCRIPTION
aims to fix issue #75 , tested on the system that caused the issue, works as intended, may need more testing on non-bugged systems to make sure there are no regressions.