### PR TITLE
Add old size to laihost_realloc() and laihost_free() calls

### DIFF
--- a/core/exec.c
+++ b/core/exec.c
@@ -48,13 +48,13 @@ void lai_finalize_state(lai_state_t *state) {
     lai_exec_pop_opstack(state, state->opstack_ptr);
 
     if (state->ctxstack_base != state->small_ctxstack)
-        laihost_free(state->ctxstack_base);
+        laihost_free(state->ctxstack_base, state->ctxstack_capacity * sizeof(struct lai_ctxitem));
     if (state->blkstack_base != state->small_blkstack)
-        laihost_free(state->blkstack_base);
+        laihost_free(state->blkstack_base, state->blkstack_capacity * sizeof(struct lai_blkitem));
     if (state->stack_base != state->small_stack)
-        laihost_free(state->stack_base);
+        laihost_free(state->stack_base, state->stack_capacity * sizeof(lai_stackitem_t));
     if (state->opstack_base != state->small_opstack)
-        laihost_free(state->opstack_base);
+        laihost_free(state->opstack_base, state->opstack_capacity * sizeof(struct lai_operand));
 }
 
 static int lai_compare(lai_variable_t *lhs, lai_variable_t *rhs) {
@@ -2571,9 +2571,8 @@ static lai_api_error_t lai_exec_parse(int parse_mode, lai_state_t *state) {
         lai_exec_commit_pc(state, pc);
 
         if (lai_current_instance()->trace & LAI_TRACE_OP){
-            char* path = lai_stringify_amlname(&amln);
+            LAI_CLEANUP_FREE_STRING char* path = lai_stringify_amlname(&amln);
             lai_debug("lai_exec_parse: ExternalOp, Name: %s, Object type: %02X, Argument Count: %01X", path, object_type, argument_count);
-            laihost_free(path);
         }
         break;
     }

--- a/core/exec_impl.h
+++ b/core/exec_impl.h
@@ -237,7 +237,7 @@ static inline int lai_exec_reserve_ctxstack(lai_state_t *state) {
         memcpy(new_stack, state->ctxstack_base,
                (state->ctxstack_ptr + 1) * sizeof(struct lai_ctxitem));
         if (state->ctxstack_base != state->small_ctxstack)
-            laihost_free(state->ctxstack_base);
+            laihost_free(state->ctxstack_base, state->ctxstack_capacity * sizeof(struct lai_ctxitem));
         state->ctxstack_base = new_stack;
         state->ctxstack_capacity = new_capacity;
     }
@@ -269,7 +269,7 @@ static inline void lai_exec_pop_ctxstack_back(lai_state_t *state) {
             lai_var_finalize(&ctxitem->invocation->arg[i]);
         for (int i = 0; i < 8; i++)
             lai_var_finalize(&ctxitem->invocation->local[i]);
-        laihost_free(ctxitem->invocation);
+        laihost_free(ctxitem->invocation, sizeof(*ctxitem->invocation));
     }
     state->ctxstack_ptr -= 1;
 }
@@ -289,7 +289,7 @@ static inline int lai_exec_reserve_blkstack(lai_state_t *state) {
         memcpy(new_stack, state->blkstack_base,
                (state->blkstack_ptr + 1) * sizeof(struct lai_blkitem));
         if (state->blkstack_base != state->small_blkstack)
-            laihost_free(state->blkstack_base);
+            laihost_free(state->blkstack_base, state->blkstack_capacity * sizeof(struct lai_blkitem));
         state->blkstack_base = new_stack;
         state->blkstack_capacity = new_capacity;
     }
@@ -333,7 +333,7 @@ static inline int lai_exec_reserve_stack(lai_state_t *state) {
         memcpy(new_stack, state->stack_base,
                (state->stack_ptr + 1) * sizeof(lai_stackitem_t));
         if (state->stack_base != state->small_stack)
-            laihost_free(state->stack_base);
+            laihost_free(state->stack_base, state->stack_capacity * sizeof(lai_stackitem_t));
         state->stack_base = new_stack;
         state->stack_capacity = new_capacity;
     }
@@ -390,7 +390,7 @@ static inline int lai_exec_reserve_opstack(lai_state_t *state) {
         memcpy(new_stack, state->opstack_base,
                state->opstack_ptr * sizeof(struct lai_operand));
         if (state->opstack_base != state->small_opstack)
-            laihost_free(state->opstack_base);
+            laihost_free(state->opstack_base, state->opstack_capacity * sizeof(struct lai_operand));
         state->opstack_base = new_stack;
         state->opstack_capacity = new_capacity;
     }

--- a/core/ns.c
+++ b/core/ns.c
@@ -66,7 +66,7 @@ void lai_install_nsnode(lai_nsnode_t *node) {
         if (!new_capacity)
             new_capacity = 128;
         lai_nsnode_t **new_array;
-        new_array = laihost_realloc(instance->ns_array, sizeof(lai_nsnode_t *) * new_capacity);
+        new_array = laihost_realloc(instance->ns_array, sizeof(lai_nsnode_t *) * new_capacity, sizeof(lai_nsnode_t *) * instance->ns_capacity);
         if (!new_array)
             lai_panic("could not reallocate namespace table");
         instance->ns_array = new_array;
@@ -230,6 +230,10 @@ char *lai_stringify_amlname(const struct lai_amlname *in_amln) {
     }
     str[n++] = '\0';
     LAI_ENSURE(n <= (int) max_length);
+
+    if (n != max_length)
+        str = laihost_realloc(str, n, max_length);
+
     return str;
 }
 

--- a/core/util-hash.h
+++ b/core/util-hash.h
@@ -41,11 +41,11 @@ static void lai_hashtable_grow(struct lai_hashtable *ht, int n, int m) {
     }
 
     if (ht->elem_capacity) {
-        laihost_free(ht->elem_ptr_tab);
-        laihost_free(ht->elem_hash_tab);
+        laihost_free(ht->elem_ptr_tab, ht->elem_capacity * sizeof(void *));
+        laihost_free(ht->elem_hash_tab, ht->elem_capacity * sizeof(int));
     }
     if (ht->bucket_capacity)
-        laihost_free(ht->bucket_tab);
+        laihost_free(ht->bucket_tab, ht->bucket_capacity * sizeof(int));
 
     ht->elem_ptr_tab = new_elem_ptr_tab;
     ht->elem_hash_tab = new_elem_hash_tab;

--- a/core/variable.c
+++ b/core/variable.c
@@ -11,8 +11,8 @@
 static void laihost_free_package(lai_variable_t *object) {
     for(size_t i = 0; i < object->pkg_ptr->size; i++)
         lai_var_finalize(&object->pkg_ptr->elems[i]);
-    laihost_free(object->pkg_ptr->elems);
-    laihost_free(object->pkg_ptr);
+    laihost_free(object->pkg_ptr->elems, object->pkg_ptr->size * sizeof(lai_variable_t));
+    laihost_free(object->pkg_ptr, sizeof(struct lai_pkg_head));
 }
 
 void lai_var_finalize(lai_variable_t *object) {
@@ -20,15 +20,15 @@ void lai_var_finalize(lai_variable_t *object) {
         case LAI_STRING:
         case LAI_STRING_INDEX:
             if (lai_rc_unref(&object->string_ptr->rc)) {
-                laihost_free(object->string_ptr->content);
-                laihost_free(object->string_ptr);
+                laihost_free(object->string_ptr->content, object->string_ptr->capacity);
+                laihost_free(object->string_ptr, sizeof(struct lai_string_head));
             }
             break;
         case LAI_BUFFER:
         case LAI_BUFFER_INDEX:
             if (lai_rc_unref(&object->buffer_ptr->rc)) {
-                laihost_free(object->buffer_ptr->content);
-                laihost_free(object->buffer_ptr);
+                laihost_free(object->buffer_ptr->content, object->buffer_ptr->size);
+                laihost_free(object->buffer_ptr, sizeof(struct lai_buffer_head));
             }
             break;
         case LAI_PACKAGE:

--- a/include/lai/host.h
+++ b/include/lai/host.h
@@ -34,8 +34,8 @@ struct lai_sync_state {
 
 // OS-specific functions.
 void *laihost_malloc(size_t);
-void *laihost_realloc(void *, size_t);
-void laihost_free(void *);
+void *laihost_realloc(void *, size_t newsize, size_t oldsize);
+void laihost_free(void *, size_t);
 
 __attribute__((weak)) void laihost_log(int, const char *);
 __attribute__((weak, noreturn)) void laihost_panic(const char *);

--- a/include/lai/internal-exec.h
+++ b/include/lai/internal-exec.h
@@ -68,6 +68,7 @@ typedef struct lai_variable_t
 
 struct lai_string_head {
     lai_rc_t rc;
+    size_t capacity;
     char *content;
 };
 

--- a/include/lai/internal-util.h
+++ b/include/lai/internal-util.h
@@ -9,6 +9,8 @@
 extern "C" {
 #endif
 
+size_t lai_strlen(const char *);
+
 // Even in freestanding environments, GCC requires memcpy(), memmove(), memset()
 // and memcmp() to be present. Thus, we just use them directly.
 void *memcpy(void *, const void *, size_t);
@@ -40,7 +42,7 @@ __attribute__((noreturn)) void lai_panic(const char *, ...);
 
 static inline void lai_cleanup_free_string(char **v) {
     if (*v)
-        laihost_free(*v);
+        laihost_free(*v, lai_strlen(*v) + 1);
 }
 
 #define LAI_CLEANUP_FREE_STRING __attribute__((cleanup(lai_cleanup_free_string)))


### PR DESCRIPTION
To accomodate this and have all of the sizes available, I had to do the following
- Add a capacity field to `lai_string_head`
- Add a realloc to `lai_stringify_amlname` to ensure `capacity == strlen() + 1` where it's used
- Forward declare `lai_strlen` in `include/lai/internal-util.h` for `lai_cleanup_free_string`

Providing the old size of the allocation gives more flexibility on the type of allocator you can use to back the laihost memory managment functions.

Of course, if you only back them using `malloc`/`free`, this is a small memory usage pessimization (the 8 bytes extra in `lai_string_head`), but I bet a lot of people who implements an OS and uses lai usually has a more efficient way to allocate given an already known allocation size.

As far as I can tell, this code only adds new data to the host, and should therefore not break any existing code. All the tests currently pass with this code too.

I didn't test the old sizes much. I added some debug printing to the `lai_tools` and ran the test suite. I didn't run any tools on the output, but it generally looked like all of the sizes were consistent.